### PR TITLE
Rename library to all lower case to match wolfssl.h case

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=wolfSSL
+name=wolfssl
 version=5.6.6-Arduino.1
 author=wolfSSL inc
 maintainer=wolfSSL inc <support@wolfssl.com>


### PR DESCRIPTION
I called the library [wolfSSL](https://github.com/wolfSSL/Arduino-wolfSSL/blob/e858748e63d09a19ade0dfd9888c95fcb8bb8c0e/library.properties#L1) but included a file called [wolfssl.h](https://github.com/wolfSSL/Arduino-wolfSSL/blob/e858748e63d09a19ade0dfd9888c95fcb8bb8c0e/library.properties#L1). 

The case of the library name in `library.properties` needs to match the case of the filename: `wolfssl.h`.

See https://github.com/arduino/library-registry/pull/4056