### PR TITLE
Improve Arduino Examples

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability, please report it to support@wolfssl.com
+
+ 1. Include a detailed description
+ 2. Include method to reproduce and/or method of discovery
+ 3. We will evaluate the report promptly and respond to you with findings.
+ 4. We will credit you with the report if you would like.
+
+**Please keep the vulnerability private** until a fix has been released.

--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -1,0 +1,307 @@
+name: Arduino CI Build (4 of 4) Arduino-wolfSSL
+
+#
+# Test local Arduino examples with LATEST github master branch wolfssl
+#
+# These 4 workflows across 3 repos are interdependent for the current $REPO_OWNER:
+#
+# Arduino CI Build 1: https://github.com/$REPO_OWNER/wolfssl               #  /.github/workflows/arduino.yml
+#   - Builds Arduino library from local clone of wolfssl master branch
+#   - Fetches examples from https://github.com/$REPO_OWNER/wolfssl-examples
+#
+# Arduino CI Build 2: https://github.com/$REPO_OWNER/wolfssl-examples      #  /.github/workflows/arduino-release.yml
+#    - Tests examples based on latest published release of Arduino library, NOT latest on wolfssl github.
+#    - Should be identical to Arduino CI Build 3 in every way but wolfssl install.
+#    - Copies only compile script from wolfssl-examples
+#    - Builds local examples
+#    - No other repos used
+#
+# Arduino CI Build 3: https://github.com/$REPO_OWNER/wolfssl-examples      #  /.github/workflows/arduino.yml
+#   - Fetches current wolfSSL from https://github.com/$REPO_OWNER/wolfssl
+#   - Creates an updated Arduino library
+#   - Compiles local examples
+#   - Contains the source of `compile-all-examples.sh` and respective board-list.txt
+#
+# THIS Arduino CI Build 4: https://github.com/$REPO_OWNER/Arduino-wolfssl   #  /.github/workflows/arduino.yml
+#    - Assembles and installs an updated Arduino wolfssl library from LOCAL Arduino-wolfSSL repo master (main) source
+#    - Copies only compile script and board list from wolfssl-examples (no examples copied)
+#    - Builds local examples
+#    - No other repos used
+#
+#
+#                                   ** NOTE TO MAINTAINERS **
+#
+#           Consider using winmerge or similar tool to keep the 4 arduino[-release].yml files in relative sync.
+#           Although there are some specific differences, most of the contents are otherwise identical.
+#
+# See https://github.com/wolfSSL/Arduino-wolfSSL
+#
+# To test locally:
+# cd [your WOLFSSL_ROOT], e.g. cd /mnt/c/workspace/wolfssl-$USER
+# [optional checkout]     e.g. git checkout tags/v5.8.2-stable
+# pushd ./IDE/ARDUINO
+# export ARDUINO_ROOT="$HOME/Arduino/libraries"
+# ./wolfssl-arduino.sh INSTALL
+# cd [your WOLFSSL_EXAMPLES_ROOT] e.g. /mnt/c/workspace/wolfssl-examples-$USER
+#
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ '**', 'master', 'main', 'release/**' ]
+
+  pull_request:
+    branches: [ '**' ]
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build:
+    # if: github.repository_owner == 'wolfssl'
+    runs-on: ubuntu-latest
+    env:
+      REPO_OWNER: ${{ github.repository_owner }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Arduino CLI
+        run: |
+          # Script to fetch and run install.sh from arduino/arduino-cli
+
+          # The install script will test to see if the recently installed apps in in the path
+          # So set it up in advance:
+          mkdir -p "${PWD}/bin"
+          echo "${PWD}/bin" >> $GITHUB_PATH
+
+          # Sets the install directory to a consistent path at the repo root.
+          ROOT_BIN="$GITHUB_WORKSPACE/bin"
+
+          # Ensures that BINDIR exists before the installer runs
+          mkdir -p "$ROOT_BIN"
+
+          # Save as a lobal environment variable
+          echo "$ROOT_BIN" >> "$GITHUB_PATH"
+
+          # Download and run install script from Arduino:
+          # -S show errors; -L follow redirects; -v Verbose
+          set +e                 # don't abort on error
+          set -o pipefail
+
+          curl -vSL --retry 5 --retry-delay 10 \
+             https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh  \
+             | sh -x
+          rc=$?
+          c_rc=${PIPESTATUS[0]}  # curl's exit code
+          s_rc=${PIPESTATUS[1]}  # sh's  exit code
+
+          set -e                 # restore default abort-on-error
+
+          # If there was a curl error, we have our own local copy that is more reliable and can add our own debugging
+          if [ "$rc" -ne 0 ]; then
+            echo "Primary install failed: curl=$c_rc, sh=$s_rc. Falling back..." >&2
+            echo "Using local copy of arduino_install.sh"
+            pushd ./Arduino/sketches
+              chmod +x ./arduino_install.sh
+
+              # Mimic curl install, does not use current directory:
+              BINDIR="$ROOT_BIN" sh -x ./arduino_install.sh
+            popd
+          else
+            echo "Alternative install script not needed."
+          fi
+
+      - name: Confirm Arduino CLI install
+        run: arduino-cli version
+
+      - name: Setup Arduino CLI
+        run: |
+          arduino-cli config init
+          arduino-cli core update-index
+          arduino-cli config add board_manager.additional_urls https://www.pjrc.com/teensy/package_teensy_index.json
+          arduino-cli core update-index
+          arduino-cli config add board_manager.additional_urls https://arduino.esp8266.com/stable/package_esp8266com_index.json
+          arduino-cli core update-index
+          arduino-cli core install esp32:esp32            # ESP32
+          arduino-cli core install arduino:avr            # Arduino Uno, Mega, Nano
+          arduino-cli core install arduino:sam            # Arduino Due
+          arduino-cli core install arduino:samd           # Arduino Zero
+          arduino-cli core install teensy:avr             # PJRC Teensy
+          arduino-cli core install esp8266:esp8266        # ESP8266
+          arduino-cli core install arduino:mbed_nano      # nanorp2040connect
+          arduino-cli core install arduino:mbed_portenta  # portenta_h7_m7
+          arduino-cli core install arduino:mbed_edge
+          # sudo "/home/$USER/.arduino15/packages/arduino/hardware/mbed_nano/4.2.4/post_install.sh"
+          arduino-cli core install arduino:renesas_uno
+          arduino-cli lib install "ArduinoJson"           # Example dependency
+          arduino-cli lib install "WiFiNINA"              # ARDUINO_SAMD_NANO_33_IOT
+          arduino-cli lib install "Ethernet"              # Install Ethernet library
+          arduino-cli lib install "Bridge"                # Pseudo-network for things like arduino:samd:tian
+
+      - name: Set job environment variables
+        run: |
+          # Script to assign some common environment variables after everything is installed
+
+          ICON_OK=$(printf "\xE2\x9C\x85")
+          ICON_FAIL=$(printf "\xE2\x9D\x8C")
+
+          echo "GITHUB_WORK=$(realpath           "$GITHUB_WORKSPACE/../..")"  >> "$GITHUB_ENV"
+          echo "ARDUINO_ROOT=$(realpath          "$HOME/Arduino/libraries")"  >> "$GITHUB_ENV"
+
+          # Show predefined summary:
+          echo "GITHUB_WORKSPACE      = $GITHUB_WORKSPACE"
+
+          # Show assigned build:env values (e.g. "wolfssl", "gojimmpi" or other owners):
+          echo "REPO_OWNER            = $REPO_OWNER"
+
+          echo "GITHUB_ENV=$GITHUB_ENV"
+
+          # Show our custom values:
+          echo "GITHUB_WORK           = $GITHUB_WORK"
+          echo "ARDUINO_ROOT          = $ARDUINO_ROOT"
+
+          # WOLFSSL_EXAMPLES_ROOT is the report root, not example location
+          # echo "WOLFSSL_EXAMPLES_ROOT = $WOLFSSL_EXAMPLES_ROOT"
+
+    # - name: Show wolfssl-examples
+          # (not used, as wolfssl source is already here in ARduino-wolfSSL)
+
+          # end Show wolfssl-examples
+
+    # - name: Shallow clone wolfssl
+          # (not used, as wolfssl source is already here in Arduino-wolfSSL)
+          #
+
+          # ** END ** Set job environment variables
+
+      - name: Get wolfssl-examples
+        run: |
+          # The wolfSSL examples should already be installed in this Arduino-wolfssl/examples directory
+
+          echo "Current pwd for wolfssl-examples clone fetch: $(pwd)"
+          echo "Examples found:"
+          find ./examples -type f | sort
+
+          # ** END ** Get wolfssl-examples
+
+      - name: Install wolfSSL Arduino library
+        run: |
+          # Script for installing wolfssl from this Arduino-wolfssl library repository
+          #
+          # Steps are equivalent of:
+          #
+          #    arduino-cli lib install "wolfSSL"
+          #
+          # But using the current repo as the source:
+          mkdir -p "$ARDUINO_ROOT/wolfssl"
+
+          # Methods of installing Arduino library:
+          #   1) arduino-cli lib install "wolfSSL"
+          #   2) manual copy of files (typical of the Arduino-wolfssl repo)
+          #   3) run ./wolfssl-arduino.sh INSTALL (typical of the wolfssl repo)
+
+          # Copy all file in current directory as root of the wolfssl library
+          echo "cp  [root files]     \"$ARDUINO_ROOT/wolfssl/src\""
+          for f in ./*; do
+            if [ -f "$f" ]; then
+              cp "$f" "$ARDUINO_ROOT/wolfssl/"
+            fi
+          done
+
+          # Only 2 directories are needed in the Arduino library: `src` and [optional] `examples`:
+          echo "cp -r  \"./src\"      \"$ARDUINO_ROOT/wolfssl/src\""
+                cp -r    ./src         "$ARDUINO_ROOT/wolfssl/src"
+
+          echo "cp -r  \"./examples\" \"$ARDUINO_ROOT/wolfssl/examples\""
+                cp -r    ./examples    "$ARDUINO_ROOT/wolfssl/examples"
+
+          # ** END ** Install wolfSSL Arduino library
+
+      - name: List installed Arduino libraries
+        run: arduino-cli lib list
+
+      - name: Get compile-all-examples.sh
+        run: |
+          # Fetch compile script FROM THE CURRENT OWNER.
+          # This repo is Arduino-wolfssl; we'll fetch the script from the wolfssl-examples for the same repository owner.
+          echo "Respository owner: $REPO_OWNER"
+          echo "Current directory: $PWD"
+          echo "Current pwd for wolfssl-examples clone fetch: $PWD"
+          WOLFSSL_EXAMPLES_DIRECTORY="$ARDUINO_ROOT/wolfssl/examples"
+          echo "WOLFSSL_EXAMPLES_DIRECTORY=$WOLFSSL_EXAMPLES_DIRECTORY"
+
+          # Fetch script and board list into WOLFSSL_EXAMPLES_DIRECTORY
+          # TODO edit PR branch path:
+          curl -L "https://raw.githubusercontent.com/$REPO_OWNER/wolfssl-examples/examples_dev/Arduino/sketches/board_list_v5.8.2.txt"          -o "$WOLFSSL_EXAMPLES_DIRECTORY/board_list.txt"
+
+          # Check if the first line is "404: Not Found" - which would indicate the curl path above is bad.
+          FILE="$WOLFSSL_EXAMPLES_DIRECTORY/board_list.txt"
+
+          # Ensure the file exists
+          if [[ ! -f "$FILE" ]]; then
+              echo "File not found: $FILE"
+              exit 1
+          fi
+
+          # Check if the first line is "404: Not Found"
+          if [[ $(head -n 1 "$FILE") == "404: Not Found" ]]; then
+              echo "The first line is '404: Not Found'"
+              exit 1
+          fi
+
+          curl -L "https://raw.githubusercontent.com/$REPO_OWNER/wolfssl-examples/examples_dev/Arduino/sketches/compile-all-examples.sh" -o "$WOLFSSL_EXAMPLES_DIRECTORY/compile-all-examples.sh"
+
+          # Check if the first line is "404: Not Found" - which would indicate the curl path above is bad.
+          FILE="$WOLFSSL_EXAMPLES_DIRECTORY/compile-all-examples.sh"
+
+          # Ensure the file exists
+          if [[ ! -f "$FILE" ]]; then
+              echo "File not found: $FILE"
+              exit 1
+          fi
+
+          # Check if the first line is "404: Not Found"
+          if [[ $(head -n 1 "$FILE") == "404: Not Found" ]]; then
+              echo "The first line is '404: Not Found'"
+              exit 1
+          fi
+
+          pushd "$WOLFSSL_EXAMPLES_DIRECTORY"
+            echo "Current directory:           $PWD"
+
+            echo "Current directory $PWD"
+            echo "Contents:"
+            ls -al
+            find ./ -type f | sort
+
+            # ensure we can execute the script here (permissions lost during curl fetch)
+            chmod +x ./compile-all-examples.sh
+            echo "Found compile script: $(ls -al ./compile-all-examples.sh)"
+          popd
+
+          # ** END ** Get compile-all-examples.sh
+
+      # This will fail with Arduino published wolfSSL v5.7.6 and older
+      # as the examples moved. See https://github.com/wolfSSL/wolfssl/pull/8514
+      #
+      - name: Compile Arduino Sketches for Various Boards
+        run: |
+          # Call the compile-all-examples.sh script to compile all the examples for each of the fqbn names in the local copy of board_list.txt
+
+          echo "Current directory:           $PWD"
+          echo "ARDUINO_ROOT:                $ARDUINO_ROOT"
+          WOLFSSL_EXAMPLES_DIRECTORY="$ARDUINO_ROOT/wolfssl/examples"
+          echo "WOLFSSL_EXAMPLES_DIRECTORY:  $WOLFSSL_EXAMPLES_DIRECTORY"
+
+          echo "Change directory to Arduino examples..."
+          pushd "$WOLFSSL_EXAMPLES_DIRECTORY"
+            echo "Current directory:           $PWD"
+            echo "Calling ./compile-all-examples.sh"
+            bash ./compile-all-examples.sh
+          popd
+          # End Compile Arduino Sketches for Various Boards

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-﻿################################################################################
+################################################################################
 # This .gitignore file was automatically created by Microsoft(R) Visual Studio.
 ################################################################################
 
@@ -9,3 +9,4 @@
 /src/wolfcrypt/src/wolfcrypt_first.c
 /src/wolfcrypt/src/wolfcrypt_last.c
 /src/wolfssl/wolfcrypt/fips.h
+/**/*.bak


### PR DESCRIPTION
# Description

This is part 3 of 3 improving Arduino examples and related GitHub workflows. See also [wolfssl #9091](https://github.com/wolfSSL/wolfssl/pull/9091) and [wolfssl-examples #519](https://github.com/wolfSSL/wolfssl-examples/pull/519)

Adds new [.github/workflows/arduino.yml](https://github.com/wolfSSL/Arduino-wolfSSL/compare/main...gojimmypi:Arduino-wolfSSL:pr-arduino-testing?expand=1#diff-9969b2f14c336deaa9664e7a0be68661e3f2b6b46233512149fcb5fd794b948e) testing workflow. Tests against local wolfSSL Arduino release.

Adds [.github/SECURITY.md](https://github.com/wolfSSL/Arduino-wolfSSL/compare/main...gojimmypi:Arduino-wolfSSL:pr-arduino-testing?expand=1#diff-ac3050733d58345444c27d37c6247ef260ad992bcb02782feea43fb580106079), same as https://github.com/wolfSSL/wolfssl/blob/master/.github/SECURITY.md

There's a bit of a chicken-and-egg problem with the 3 inter-related pull requests. For now, this one uses `board_list_v5.8.2.txt` but should be later updated to use `board_list.txt`

## Enclosed

 Arduino CI Build 4: `https://github.com/$REPO_OWNER/Arduino-wolfssl`         `/.github/workflows/arduino.yml`
    - Assembles and installs an updated Arduino wolfssl library from LOCAL wolfssl master source
    - Copies only compile script copied from wolfssl-examples
    - Builds local examples
    - No other repos used

## The other 2 parts (wolfssl-examples  and Arduino-wolfssl repos)

###  wolfssl

See https://github.com/wolfSSL/wolfssl/pull/9091:

Arduino CI Build 1: `https://github.com/$REPO_OWNER/wolfssl`                 `/.github/workflows/arduino.yml`
   - Builds Arduino library from local clone of wolfssl master branch
   - Fetches examples from https://github.com/$REPO_OWNER/wolfssl-examples


### wolfssl-examples

See https://github.com/wolfSSL/wolfssl-examples/pull/519:

 Arduino CI Build 2: `https://github.com/$REPO_OWNER/wolfssl-examples`   `/.github/workflows/arduino-release.yml`
    - Tests examples based on latest published release of Arduino library, NOT latest on wolfssl github.
    - Should be identical to Arduino CI Build 3 in every way but wolfssl install.
    - Copies only compile script from wolfssl-examples
    - Builds local examples
    - No other repos used

 Arduino CI Build 3: `https://github.com/$REPO_OWNER/wolfssl-examples`       `/.github/workflows/arduino.yml`
   - Fetches current wolfSSL from https://github.com/$REPO_OWNER/wolfssl
   - Creates an updated Arduino library
   - Compiles local examples
   - Contains the source of `compile-all-examples.sh` and respective board-list.txt


## See also my dev examples:

- [Arduino CI Build (1 of 4) wolfssl ](https://github.com/gojimmypi/wolfssl/actions/workflows/arduino.yml)
- [Arduino CI Build (2 of 4) Release Arduino wolfSSL for Local Examples](https://github.com/gojimmypi/wolfssl-examples/actions/workflows/arduino-release.yml)
- [Arduino CI Build (3 of 4) Latest wolfSSL for Local Examples](https://github.com/gojimmypi/wolfssl-examples/actions/workflows/arduino.yml)
- [Arduino CI Build (4 of 4) Arduino-wolfSSL](https://github.com/gojimmypi/Arduino-wolfSSL/actions/workflows/arduino.yml)

