### PR TITLE
Correct wolfssl-examples script fetch branch

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -237,7 +237,7 @@ jobs:
 
           # Fetch script and board list into WOLFSSL_EXAMPLES_DIRECTORY
           # TODO edit PR branch path:
-          curl -L "https://raw.githubusercontent.com/$REPO_OWNER/wolfssl-examples/examples_dev/Arduino/sketches/board_list_v5.8.2.txt"          -o "$WOLFSSL_EXAMPLES_DIRECTORY/board_list.txt"
+          curl -L "https://raw.githubusercontent.com/$REPO_OWNER/wolfssl-examples/master/Arduino/sketches/board_list_v5.8.2.txt"          -o "$WOLFSSL_EXAMPLES_DIRECTORY/board_list.txt"
 
           # Check if the first line is "404: Not Found" - which would indicate the curl path above is bad.
           FILE="$WOLFSSL_EXAMPLES_DIRECTORY/board_list.txt"
@@ -254,7 +254,7 @@ jobs:
               exit 1
           fi
 
-          curl -L "https://raw.githubusercontent.com/$REPO_OWNER/wolfssl-examples/examples_dev/Arduino/sketches/compile-all-examples.sh" -o "$WOLFSSL_EXAMPLES_DIRECTORY/compile-all-examples.sh"
+          curl -L "https://raw.githubusercontent.com/$REPO_OWNER/wolfssl-examples/master/Arduino/sketches/compile-all-examples.sh" -o "$WOLFSSL_EXAMPLES_DIRECTORY/compile-all-examples.sh"
 
           # Check if the first line is "404: Not Found" - which would indicate the curl path above is bad.
           FILE="$WOLFSSL_EXAMPLES_DIRECTORY/compile-all-examples.sh"


### PR DESCRIPTION
Updates workflow with the proper curl fetch URL for example code.

Related to https://github.com/wolfSSL/Arduino-wolfSSL/pull/20/

* Note on  workflow warning:

```
--no-wolfssl_client_dtls: there's no wolfssl_client_dtls example for the v5.8.2 release
⚠ WARN: Unknown example in flag "--no-wolfssl_client_dtls" under FQBN "arduino:avr:nano" (ignored)
--no-wolfssl_server_dtls: there's no wolfssl_server_dtls example for the v5.8.2 release
⚠ WARN: Unknown example in flag "--no-wolfssl_server_dtls" under FQBN "arduino:avr:nano" (ignored)
```

The new TLS examples are not present here (yet), and were not included in the most recent Arduino release 5.8.2

See: 

- https://github.com/wolfSSL/Arduino-wolfSSL/tree/main/examples
- https://github.com/wolfSSL/wolfssl-examples/tree/master/Arduino/sketches